### PR TITLE
fix: don't create an `__init__.py` file if `__init__.pyi` exists

### DIFF
--- a/zip/writer.go
+++ b/zip/writer.go
@@ -373,6 +373,8 @@ func (f *File) AddInitPyFiles() error {
 				break
 			} else if _, present := f.files[initPyPath+"o"]; present {
 				break
+			} else if _, present := f.files[initPyPath+"i"]; present {
+				break
 			} else if _, present := f.files[d+".py"]; present {
 				break
 			} else if _, present := sos[d]; present {


### PR DESCRIPTION
Because adding `__init__.py` breaks some python packages like "cryptography" version 36.0.1.

Fixes https://github.com/thought-machine/please/issues/2272