### PR TITLE
Use github.com/xi2/xz to extract xz archives

### DIFF
--- a/tar/BUILD
+++ b/tar/BUILD
@@ -2,7 +2,9 @@ go_library(
     name = "tar",
     srcs = ["tar.go"],
     visibility = ["//..."],
-    deps = ["//third_party/go:xz"],
+    deps = [
+        "//third_party/go:ulikunitz_xz",
+    ],
 )
 
 go_test(
@@ -12,6 +14,6 @@ go_test(
     deps = [
         ":tar",
         "//third_party/go:testify",
-        "//third_party/go:xz",
+        "//third_party/go:ulikunitz_xz",
     ],
 )

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -105,7 +105,7 @@ go_module(
 )
 
 go_module(
-    name = "xz",
+    name = "ulikunitz_xz",
     install = [
         "internal/...",
         ".",
@@ -114,6 +114,14 @@ go_module(
     licences = ["BSD-3-Clause"],
     module = "github.com/ulikunitz/xz",
     version = "v0.5.10",
+    visibility = ["PUBLIC"],
+)
+
+go_module(
+    name = "xi2_xz",
+    licences = ["Public Domain"],
+    module = "github.com/xi2/xz",
+    version = "v0.0.0-20171230120015-48954b6210f8",
     visibility = ["PUBLIC"],
 )
 

--- a/unzip/BUILD
+++ b/unzip/BUILD
@@ -3,7 +3,7 @@ go_library(
     srcs = ["unzip.go"],
     visibility = ["//:all"],
     deps = [
-        "//third_party/go:xz",
+        "//third_party/go:xi2_xz",
         "//third_party/go:zstd",
     ],
 )

--- a/unzip/unzip.go
+++ b/unzip/unzip.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 
 	"github.com/klauspost/compress/zstd"
-	"github.com/ulikunitz/xz"
+	"github.com/xi2/xz"
 )
 
 // concurrency controls the maximum level of concurrency we'll allow.
@@ -64,7 +64,7 @@ func (e *extractor) Extract() error {
 	}
 	// Reset back to the start of the file and try xz
 	f.Seek(0, io.SeekStart)
-	if r, err := xz.NewReader(f); err == nil {
+	if r, err := xz.NewReader(f, 0); err == nil {
 		return e.extractTar(r)
 	}
 	// Reset again and try bzip2


### PR DESCRIPTION
The performance of `github.com/ulikunitz/xz` when decompressing xz data is a known limitation; see https://github.com/ulikunitz/xz/issues/23. `github.com/xi2/xz` is significantly faster for xz decompression; use it in place of `github.com/ulikunitz/xz` in the `unzip` package. `github.com/xi2/xz` doesn't implement xz compression, so the `tar` package must continue to use `github.com/ulikunitz/xz`.

Performance evaluation on a sample 576MB xz-compressed tarball (the binary distribution of Clang for Ubuntu 18.04) with a dictionary size of 64MB (which corresponds to compression preset level 9) and a resulting ~13% compression ratio:

```
bash-4.4$ ls -lh $SRCS
-rw-r--r-- 2 csn users 576M Nov 19 17:54 clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz

bash-4.4$ xz -lvv $SRCS
clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz (1/1)
  Streams:            1
  Blocks:             1
  Compressed size:    575.8 MiB (603,776,352 B)
  Uncompressed size:  4,408.2 MiB (4,622,376,960 B)
  Ratio:              0.131
  Check:              CRC64
  Stream padding:     0 B
  Streams:
    Stream    Blocks      CompOffset    UncompOffset        CompSize      UncompSize  Ratio  Check      Padding
         1         1               0               0     603,776,352   4,622,376,960  0.131  CRC64            0
  Blocks:
    Stream     Block      CompOffset    UncompOffset       TotalSize      UncompSize  Ratio  Check      CheckVal          Header  Flags        CompSize    MemUsage  Filters
         1         1              12               0     603,776,312   4,622,376,960  0.131  CRC64      b4d869416c7f940f      12  --        603,776,291      65 MiB  --lzma2=dict=64MiB
  Memory needed:      65 MiB
  Sizes in headers:   No
  Minimum XZ Utils version: 5.0.0
```

With GNU tar 1.29 and liblzma 5.2.2 (a useful baseline):

```
bash-4.4$ time tar xf $SRCS

real    0m40.250s
user    0m36.544s
sys     0m6.847s
```

arcat with `github.com/ulikunitz/xz` handling xz decompression:

```
bash-4.4$ time $TOOLS_ARCAT x $SRCS

real    12m6.254s
user    4m6.769s
sys     8m4.628s
```

arcat with `github.com/xi2/xz` handling xz decompression:

```
bash-4.4$ time $TOOLS_ARCAT x $SRCS

real    0m55.643s
user    0m50.877s
sys     0m2.275s
```