### PR TITLE
Make repo compatible with Please v17

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -1,6 +1,11 @@
-[please]
-version = >=16.17.1
+[parse]
+preloadsubincludes = ///go//build_defs:go
 
-[go]
+[please]
+version = >=17.0.0
+
+[Plugin "go"]
+Target = //plugins:go
+pleasegotool = ///go//tools/please_go:bootstrap
 gotool = //third_party/go:toolchain|go
 importpath = github.com/please-build/arcat

--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,5 @@
+subinclude("///go//build_defs:go")
+
 go_binary(
     name = "arcat",
     srcs = ["main.go"],

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -1,0 +1,5 @@
+plugin_repo(
+    name = "go",
+    plugin = "go-rules",
+    revision = "v1.6.0",
+)

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -9,7 +9,7 @@ go_toolchain(
         "linux_amd64",
         "linux_arm64",
     ],
-    version = "1.17.5",
+    version = "1.19.9",
     tags = [
         "osusergo",
         "netgo",


### PR DESCRIPTION
Please 17.0.0-beta.6 removed the built-in Go rules, so the version constraint in `.plzconfig` is no longer valid - require Please 17.0.0 at a minimum, and explicitly load the Go rules from the `go-rules` repo.

This also requires the in-repo Go toolchain to be bumped to 1.19, since the version of `please_go` in `go-rules` 1.6.0 uses features added in the Go 1.19 standard library.