### PR TITLE
Truncate uncompressed files at creation

### DIFF
--- a/unzip/unzip.go
+++ b/unzip/unzip.go
@@ -174,7 +174,7 @@ func (e *extractor) extractFile(f *zip.File) error {
 	if err := e.makeParentDir(out); err != nil {
 		return err
 	}
-	o, err := os.OpenFile(out, os.O_WRONLY|os.O_CREATE, f.Mode())
+	o, err := os.OpenFile(out, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Issue: Extracted files are not truncated.
Problem: If the file already exists and it's bigger than the new one it will only write up to the size of it, leaving the rest of the file with the old content. 
Reproducing:
```
$ echo AAAAAAAA > input/a 
$ plz run :arcat -- zip -d -o file.zip -i input/a 
$ echo BB > input/a 
$ plz run :arcat -- zip -d -o file2.zip -i input/a 
$ plz run :arcat -- x file.zip
$ plz run :arcat -- x file2.zip
$ cat input/a 
BB
AAAAA

```