### PR TITLE
Stream preamble directly from `--preamble_file` to output file

### DIFF
--- a/main.go
+++ b/main.go
@@ -220,12 +220,13 @@ func main() {
 		opts.Zip.Preamble = mustReadPreamble(opts.Zip.PreambleFrom)
 	}
 	if opts.Zip.Preamble != "" {
-		must(f.WritePreamble([]byte(opts.Zip.Preamble + "\n")))
+		must(f.WritePreambleBytes([]byte(opts.Zip.Preamble + "\n")))
 	}
 	if opts.Zip.PreambleFile != "" {
-		b, err := ioutil.ReadFile(opts.Zip.PreambleFile)
+		pf, err := os.Open(opts.Zip.PreambleFile)
 		must(err)
-		must(f.WritePreamble(b))
+		defer pf.Close()
+		must(f.WritePreambleFile(pf))
 	}
 	if opts.Zip.MainClass != "" {
 		must(f.AddManifest(opts.Zip.MainClass))

--- a/zip/writer.go
+++ b/zip/writer.go
@@ -30,7 +30,7 @@ const modTimeDOS = 10785
 type File struct {
 	f              io.WriteCloser
 	w              *zip.Writer
-	preambleLength int
+	preambleLength int64
 	filename       string
 	input          string
 	// Include and Exclude are prefixes of filenames to include or exclude from the zipfile.
@@ -485,11 +485,19 @@ func (f *File) WriteDir(filename string) error {
 	return nil
 }
 
-// WritePreamble writes a preamble to the zipfile.
-func (f *File) WritePreamble(preamble []byte) error {
-	f.preambleLength += len(preamble)
-	f.w.SetOffset(int64(f.preambleLength))
+// WritePreambleBytes writes a byte slice as a preamble to the zipfile.
+func (f *File) WritePreambleBytes(preamble []byte) error {
+	f.preambleLength += int64(len(preamble))
+	f.w.SetOffset(f.preambleLength)
 	_, err := f.f.Write(preamble)
+	return err
+}
+
+// WritePreambleFile writes a file as a preamble to the zipfile.
+func (f *File) WritePreambleFile(preamble fs.File) error {
+	length, err := io.Copy(f.f, preamble)
+	f.preambleLength += length
+	f.w.SetOffset(f.preambleLength)
 	return err
 }
 


### PR DESCRIPTION
This should make `--preamble_file` more efficient when the source file is large.