### PR TITLE
Bump Go toolchain to v1.23.2

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -2,7 +2,7 @@
 preloadsubincludes = ///go//build_defs:go
 
 [please]
-version = >=17.0.0
+version = >=17.11.0
 
 [Plugin "go"]
 Target = //plugins:go

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -1,5 +1,5 @@
 plugin_repo(
     name = "go",
     plugin = "go-rules",
-    revision = "v1.6.0",
+    revision = "v1.21.5",
 )

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -9,7 +9,7 @@ go_toolchain(
         "linux_amd64",
         "linux_arm64",
     ],
-    version = "1.19.9",
+    version = "1.23.2",
     tags = [
         "osusergo",
         "netgo",


### PR DESCRIPTION
This also requires the go-rules plugin to be bumped to v1.21.5 and the minimum Please version to be bumped to v17.11.0, for go-rules' benefit.