### PR TITLE
Explicitly make `zip` preamble options mutually exclusive

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,20 +32,6 @@ var javaExcludePrefixes = []string{
 
 var log = logging.MustGetLogger()
 
-// countFunc returns the number of elements in s that satisfy f.
-func countFunc[S []E, E comparable](s S, f func(e E) bool) int {
-	var n int
-	for {
-		i := slices.IndexFunc(s, f)
-		if i == -1 {
-			break
-		}
-		n++
-		s = s[i+1:]
-	}
-	return n
-}
-
 func must(err error) {
 	if err != nil {
 		log.Fatalf("%s", err)
@@ -194,11 +180,11 @@ func main() {
 		os.Exit(0)
 	}
 
-	if countFunc([]string{
+	if len(slices.DeleteFunc([]string{
 		opts.Zip.Preamble,
 		opts.Zip.PreambleFrom,
 		opts.Zip.PreambleFile,
-	}, func(s string) bool { return s != "" }) > 1 {
+	}, func(s string) bool { return s == "" })) > 1 {
 		log.Fatal("Only one of --preamble, --preamble_from or --preamble_file may be specified.")
 	}
 


### PR DESCRIPTION
The `--preamble`, `--preamble_from` and `--preamble_file` options to the `zip` command exhibit strange behaviour when more than one of them is specified. If `--preamble_file` and either of the other two options are given, the preamble from `--preamble`/`--preamble_from` will be written first, followed by the contents of `--preamble_file`. If `--preamble` and `--preamble_from` are given, only `--preamble_from` is honoured. If all three are specified, only `--preamble` and `--preamble_file` are honoured.

It really only makes sense to use at most one of these options during a single invocation of the `zip` command, so exit in failure if more than one is specified.