### PR TITLE
Tidy up help text

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,21 +96,21 @@ var opts = struct {
 	} `command:"ar" alias:"a" description:"Creates a new ar archive."`
 }{
 	Usage: `
-arcat is a tool for creating, extracting and concatenating archives..
+arcat is a tool for creating, extracting and concatenating archives.
 
-Its original and most unique feature is performing efficient concatenation of .jar files
-when compiling Java code. This is possible with zip files because each file is compressed
-individually so it's possible to combine them without decompressing and recompressing each one.
+Its original and most unique feature is performing efficient concatenation of
+.jar files when compiling Java code. This is possible with zip files because
+each file is compressed individually so it's possible to combine them without
+decompressing and recompressing each one.
 
-It now has a number of other features to help in compilation and serves as a general-purpose
-zip manipulator for Please. To help us maintain reproduceability of builds it is able to strip
-timestamps from files, and also has a bunch of Python-specific functionality to help with .pex files.
+It now has a number of other features to help in compilation and serves as a
+general-purpose manipulator of archive formats for Please. To help us maintain
+reproduceability of builds it is able to strip timestamps from files, and also
+has a bunch of Python-specific functionality to help with .pex files.
 
-Typically you don't invoke this directly, Please will run it when individual rules need it.
-You're welcome to use it separately if you find it useful, although be aware that we do not
-aim to maintain compatibility very strongly.
-
-Any apparent relationship between the name of this tool and bonsai kittens is completely coincidental.
+Typically you don't invoke this directly, Please will run it when individual
+rules need it. You're welcome to use it separately if you find it useful,
+although be aware that we do not aim to maintain compatibility very strongly.
 `,
 }
 


### PR DESCRIPTION
Wrap at 80 characters and remove the jarcat reference (unfortunately it doesn't make any sense now that the tool is called arcat...)