### PR TITLE
Bump github.com/please-build/ar to v0.0.0-20251008230604-d346232a9254

### DIFF
--- a/ar/ar.go
+++ b/ar/ar.go
@@ -84,8 +84,6 @@ func Create(srcs []string, out string, combine, rename bool) error {
 				hdr.ModTime = mtime
 				hdr.Uid = 0
 				hdr.Gid = 0
-				// Fix weird bug about octal numbers (looks like we're prepending 100 multiple times)
-				hdr.Mode &= ^0100000
 				log.Debug("copying '%s' in from %s, mode %x", hdr.Name, src, hdr.Mode)
 				if err := w.WriteHeader(hdr); err != nil {
 					return fmt.Errorf("write ar header: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/klauspost/compress v1.13.6
 	github.com/peterebden/go-cli-init/v5 v5.2.0
-	github.com/please-build/ar v0.0.0-20251007213405-d4c8bd5ce6fe
+	github.com/please-build/ar v0.0.0-20251008230604-d346232a9254
 	github.com/stretchr/testify v1.11.1
 	github.com/ulikunitz/xz v0.5.10
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQ
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/peterebden/go-cli-init/v5 v5.2.0 h1:T4WfGF+XjYCdVR4Y9KcTRVGpY5f6UelP0WDNuvn3Twc=
 github.com/peterebden/go-cli-init/v5 v5.2.0/go.mod h1:CAwh3oj26LCNv9zLsWCDWlPnERwAeQTDsHTSGqobV3Q=
-github.com/please-build/ar v0.0.0-20251007213405-d4c8bd5ce6fe h1:0di7jrH0bgbJvl19JNpNAyP+4+yVvx2UHKFtW1Y5aCg=
-github.com/please-build/ar v0.0.0-20251007213405-d4c8bd5ce6fe/go.mod h1:d0kfgTsdJGeKNmpnBKgsZGOCwbfYCTQ+nHKc2hE65ec=
+github.com/please-build/ar v0.0.0-20251008230604-d346232a9254 h1:Kyk3pq9DOBbdRfqA4t0JxakrFc/c79hlEYtByqmOAps=
+github.com/please-build/ar v0.0.0-20251008230604-d346232a9254/go.mod h1:d0kfgTsdJGeKNmpnBKgsZGOCwbfYCTQ+nHKc2hE65ec=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -101,7 +101,7 @@ go_module(
     name = "ar",
     licences = ["MIT"],
     module = "github.com/please-build/ar",
-    version = "v0.0.0-20251007213405-d4c8bd5ce6fe",
+    version = "v0.0.0-20251008230604-d346232a9254",
     visibility = ["PUBLIC"],
 )
 


### PR DESCRIPTION
This fixes several ar handling bugs:

- Treat BSD file names containing spaces like long file names when writing
- Ensure trailing slash is appended to all GNU file names when writing
- Ensure buffer is completely filled when reading the data section of an archive member
- Don't prepend our own file mode bits when writing file mode fields
- Don't write a file mode for GNU string tables