### PR TITLE
Remove remaining references to the previous "jarcat" name

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Package main implements jarcat, a program to efficiently concatenate .zip files.
+// Package main implements arcat, a program to efficiently concatenate .zip files.
 // Originally this was pretty simple and that was all it could do, over time it's
 // gained a bunch more features on a more or less as needed basis.
 //
@@ -172,7 +172,7 @@ func main() {
 		opts.Zip.ExcludeInternalPrefix = javaExcludePrefixes
 	}
 
-	tempFile, err := ioutil.TempFile(".", "jarcat-")
+	tempFile, err := ioutil.TempFile(".", "arcat-")
 	must(err)
 	filename := tempFile.Name()
 

--- a/unzip/unzip.go
+++ b/unzip/unzip.go
@@ -1,4 +1,4 @@
-// Package unzip implements unzipping for jarcat.
+// Package unzip implements unzipping for arcat.
 // We implement this to avoid needing a runtime dependency on unzip,
 // which is not a profound package but not installed everywhere by default.
 package unzip

--- a/zip/writer.go
+++ b/zip/writer.go
@@ -1,4 +1,4 @@
-// Package zip implements functions for jarcat that manipulate .zip files.
+// Package zip implements functions for arcat that manipulate .zip files.
 package zip
 
 import (


### PR DESCRIPTION
The only user-visible change here is the renaming of the temporary directory that arcat creates as a working directory for writing zip files.