### PR TITLE
Bump github.com/please-build/ar to v0.0.0-20251128102243-20fe5956df94

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/klauspost/compress v1.13.6
 	github.com/peterebden/go-cli-init/v5 v5.2.0
-	github.com/please-build/ar v0.0.0-20251008230604-d346232a9254
+	github.com/please-build/ar v0.0.0-20251128102243-20fe5956df94
 	github.com/stretchr/testify v1.11.1
 	github.com/ulikunitz/xz v0.5.10
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/peterebden/go-cli-init/v5 v5.2.0 h1:T4WfGF+XjYCdVR4Y9KcTRVGpY5f6UelP0
 github.com/peterebden/go-cli-init/v5 v5.2.0/go.mod h1:CAwh3oj26LCNv9zLsWCDWlPnERwAeQTDsHTSGqobV3Q=
 github.com/please-build/ar v0.0.0-20251008230604-d346232a9254 h1:Kyk3pq9DOBbdRfqA4t0JxakrFc/c79hlEYtByqmOAps=
 github.com/please-build/ar v0.0.0-20251008230604-d346232a9254/go.mod h1:d0kfgTsdJGeKNmpnBKgsZGOCwbfYCTQ+nHKc2hE65ec=
+github.com/please-build/ar v0.0.0-20251128102243-20fe5956df94 h1:HMGl3GsklLOGFriw51we+FLV4Oh3FgwrYxCKSK1N3jU=
+github.com/please-build/ar v0.0.0-20251128102243-20fe5956df94/go.mod h1:d0kfgTsdJGeKNmpnBKgsZGOCwbfYCTQ+nHKc2hE65ec=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -101,7 +101,7 @@ go_module(
     name = "ar",
     licences = ["MIT"],
     module = "github.com/please-build/ar",
-    version = "v0.0.0-20251008230604-d346232a9254",
+    version = "v0.0.0-20251128102243-20fe5956df94",
     visibility = ["PUBLIC"],
 )
 


### PR DESCRIPTION
This fixes a bug whereby symbol tables in BSD-variant ar archives are erroneously treated as real files, and are therefore copied into output archives when input archives are merged via `--combine` - see https://github.com/please-build/ar/issues/22.